### PR TITLE
Subgraph update: optimization

### DIFF
--- a/src/bots/proof-of-humanity/change-state-to-pending.js
+++ b/src/bots/proof-of-humanity/change-state-to-pending.js
@@ -6,19 +6,36 @@ const { gql } = require('graphql-request')
 // - The requester must have paid their fees.
 // - The required number of vouches are required.
 module.exports = async (graph, proofOfHumanity) => {
+  const {
+    contract: { requiredNumberOfVouches, submissionDuration }
+  } = await graph.request(
+    gql`
+      query contractVariablesQuery {
+        contract(id: 0) {
+          requiredNumberOfVouches
+          submissionDuration
+        }
+      }
+    `
+  )
+
   let lastSubmisionID = "";
-  let allSubmissions = [];
+  let validSubmissions = [];
   while (true) {
     const {
       submissions
     } = await graph.request(
       gql`
-        query changeStateToPendingQuery($lastId: String) {
-          # The submission must have the vouching status.
+        query changeStateToPendingQuery($lastId: String, $submissionTimestamp: BigInt) {
+          # The submission must have the Vouching status.
           # Use id_gt instead of skip for better performance.
           submissions(where: { status: "Vouching", id_gt: $lastId }, first: 1000) {
             id
+            vouchesReceived(where: { usedVouch: null, registered: true, submissionTime_gt: $submissionTimestamp }) {
+              id
+            }
             requests(orderBy: creationTime, orderDirection: desc, first: 1) {
+              creationTime
               challenges(orderBy: creationTime, orderDirection: desc, first: 1) {
                 rounds(orderBy: creationTime, orderDirection: desc, first: 1) {
                   hasPaid
@@ -30,74 +47,48 @@ module.exports = async (graph, proofOfHumanity) => {
       `,
       {
         lastId: lastSubmisionID,
+        submissionTimestamp: Date.now() - submissionDuration,
       }
     )
-    allSubmissions = allSubmissions.concat(submissions)
+    validSubmissions = validSubmissions.concat(
+      submissions.filter(
+        // Filter out submissions that are not fully funded.
+        (submission) =>
+          submission.requests[0].challenges[0].rounds[0].hasPaid[0]
+      )
+    )
     if (submissions.length < 1000) break
     lastSubmisionID = submissions[submissions.length-1].id
   }
 
-  let submissionsWithVouches = await Promise.all(
-    allSubmissions
-      // The requester must have paid their fees.
-      .filter(
-        (submission) =>
-          submission.requests[0].challenges[0].rounds[0].hasPaid[0]
-      )
-      .map(async (submission) => ({
-        ...submission,
-        vouches: (await graph.request(
-          gql`
-            query vouchesQuery($id: [ID!]!) {
-              submissions(where: { vouchees_contains: $id, usedVouch: null, registered: true }) {
-                id
-              }
-            }
-          `,
-          {
-            id: [submission.id],
-          }
-        )).submissions.map((submission) => submission.id),
-      }))
-  )
-
-  const {
-    contract: { requiredNumberOfVouches }
-  } = await graph.request(
-    gql`
-      query contractVariablesQuery {
-        contract(id: 0) {
-          requiredNumberOfVouches
-        }
-      }
-    `
-  )
+  // Prioritize older submissions (follow FIFO when two submissions share the same vouches).
+  validSubmissions.sort((a, b) => { a.request[0].creationTime - b.request[0].creationTime });
 
   // Addresses are allowed to vouch many submissions simultaneously.
   // However, only one vouch per address can be used at a time.
   // Therefore, duplicated vouchers are removed in the following lines.
   let usedVouches = []
-  for (i = 0; i < submissionsWithVouches.length; i++) {
-    for (j = submissionsWithVouches[i].vouches.length-1; j >= 0; j--) {
+  for (i = 0; i < validSubmissions.length; i++) {
+    for (j = validSubmissions[i].vouchesReceived.length-1; j >= 0; j--) {
       // Iterates vouches backwards in order to remove duplicates on the go.
-      if (usedVouches.includes(submissionsWithVouches[i].vouches[j])) {
-        submissionsWithVouches[i].vouches.splice(j, 1);
+      if (usedVouches.includes(validSubmissions[i].vouchesReceived[j])) {
+        validSubmissions[i].vouchesReceived.splice(j, 1);
       }
     }
-    if (submissionsWithVouches[i].vouches.length >= Number(requiredNumberOfVouches)) {
+    if (validSubmissions[i].vouchesReceived.length >= Number(requiredNumberOfVouches)) {
       // Only consider submissions with enough vouches to pass to PendingRegistration.
-      usedVouches = [...usedVouches, ...submissionsWithVouches[i].vouches]
+      usedVouches = [...usedVouches, ...validSubmissions[i].vouchesReceived]
     }
   }
 
   return (
-    submissionsWithVouches
+    validSubmissions
       .filter(
         (submission) =>
-          submission.vouches.length >= Number(requiredNumberOfVouches)
+          submission.vouchesReceived.length >= Number(requiredNumberOfVouches)
       )
       .map((submission) => ({
-        args: [submission.id, submission.vouches, [], []],
+        args: [submission.id, submission.vouchesReceived, [], []],
         method: proofOfHumanity.methods.changeStateToPending,
         to: proofOfHumanity.options.address,
     }))

--- a/src/bots/proof-of-humanity/execute-registrations.js
+++ b/src/bots/proof-of-humanity/execute-registrations.js
@@ -44,9 +44,8 @@ module.exports = async (graph, proofOfHumanity) => {
     lastSubmisionID = submissions[submissions.length-1].id
   }
 
-  const AUTO_PROCESSED_VOUCH = 10
-
-  const executeRegistrations = allSubmissions
+  return (
+    allSubmissions
     // The request can't be disputed.
     // The challenge period must have passed.
     .filter(
@@ -55,15 +54,10 @@ module.exports = async (graph, proofOfHumanity) => {
         Date.now() - request.lastStatusChange * 1000 >
           challengePeriodDuration * 1000
     )
-    .map(submission => ([{
+    .map(submission => ({
       args: [submission.id],
       method: proofOfHumanity.methods.executeRequest,
       to: proofOfHumanity.options.address
-    }, {
-      args: [submission.id, submission.requestsLength-1, AUTO_PROCESSED_VOUCH],
-      method: proofOfHumanity.methods.processVouches,
-      to: proofOfHumanity.options.address,
-    }]))
-
-  return [].concat(...executeRegistrations)
+    }))
+  )
 }


### PR DESCRIPTION
- Update bots according to the new subgraph proposal https://github.com/Proof-Of-Humanity/proof-of-humanity-web/pull/183.
- When moving submissions from Vouching to Pending Registration, give priority to older requests. Before, priority was given by addresses' alphabetical order.
- Allow queries bigger than 1000 in the bot that executes withdrawFeesAndRewards.

Note that the updated subgraph is needed for this bots to work. Feel free to test using https://api.thegraph.com/subgraphs/name/fnanni-0/poh-staging as the proof of humanity subgraph. It's synced with mainnet.