### PR TITLE
fix: fixed batchedSend when GAS_PRICE_CEILING env var is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "function-batch": "^1.1.2",
     "graphql": "^15.3.0",
     "graphql-request": "^3.1.0"
+  },
+  "volta": {
+    "node": "10.24.1"
   }
 }

--- a/src/utils/batched-send.js
+++ b/src/utils/batched-send.js
@@ -58,7 +58,7 @@ module.exports = (
     ).then(_pendingBatches => (pendingBatches = _pendingBatches))
 
     const currentGasPrice = web3.utils.toBN(await web3.eth.getGasPrice())
-    const maxGasPrice = process.env.GAS_PRICE_CEILING_WEI
+    const maxGasPrice = !!process.env.GAS_PRICE_CEILING_WEI ? process.env.GAS_PRICE_CEILING_WEI : currentGasPrice
     const gasPrice = currentGasPrice.gt(web3.utils.toBN(maxGasPrice))
       ? maxGasPrice
       : currentGasPrice.toString()

--- a/src/xdai-bots/x-kleros-liquid.js
+++ b/src/xdai-bots/x-kleros-liquid.js
@@ -182,6 +182,7 @@ module.exports = async (web3, batchedSend) => {
 
     if (readyForNextPhase) {
       batchedSend({
+        args: [],
         method: xKlerosLiquid.methods.passPhase,
         to: xKlerosLiquid.options.address
       })

--- a/src/xdai-bots/x-kleros-liquid.js
+++ b/src/xdai-bots/x-kleros-liquid.js
@@ -182,7 +182,6 @@ module.exports = async (web3, batchedSend) => {
 
     if (readyForNextPhase) {
       batchedSend({
-        args: [],
         method: xKlerosLiquid.methods.passPhase,
         to: xKlerosLiquid.options.address
       })


### PR DESCRIPTION
The bots running on xDAI don't need this environment variable, since gas fees will never be too crazy.
Instead of requiring their environment to declare it, I just made the code handle the case when there's no ceiling.