### PR TITLE
Fix: heartbeat & gas Logic

### DIFF
--- a/src/bots/kleros-liquid.js
+++ b/src/bots/kleros-liquid.js
@@ -35,7 +35,13 @@ module.exports = async (web3, batchedSend) => {
       let disputeID = 0;
       while (true) {
         if (!executedDisputeIDs[disputeID]) {
-          const dispute = await klerosLiquid.methods.disputes(disputeID).call();
+          let dispute;
+          try {
+            dispute = await klerosLiquid.methods.disputes(disputeID).call();
+          } catch (_) {
+            //console.log(e);
+            break;
+          }
           const dispute2 = await klerosLiquid.methods
             .getDispute(disputeID)
             .call();

--- a/src/bots/kleros-liquid.js
+++ b/src/bots/kleros-liquid.js
@@ -1,29 +1,21 @@
-const delay = require('delay')
-const https = require('https')
-const _klerosLiquid = require('../contracts/kleros-liquid.json')
+const delay = require("delay");
+const https = require("https");
+const _klerosLiquid = require("../contracts/kleros-liquid.json");
 
-const DELAYED_STAKES_ITERATIONS = 15
+const DELAYED_STAKES_ITERATIONS = 15;
 
 module.exports = async (web3, batchedSend) => {
   // Instantiate the Kleros Liquid contract.
   const klerosLiquid = new web3.eth.Contract(
     _klerosLiquid.abi,
     process.env.KLEROS_LIQUID_CONTRACT_ADDRESS
-  )
-  const PhaseEnum = Object.freeze({"staking": 0, "generating": 1, "drawing": 2})
+  );
+  const PhaseEnum = Object.freeze({ staking: 0, generating: 1, drawing: 2 });
 
   // Keep track of executed disputes so we don't waste resources on them.
-  const executedDisputeIDs = {}
+  const executedDisputeIDs = {};
 
   while (true) {
-    if (process.env.HEARTBEAT_URL) {
-      https
-        .get(process.env.HEARTBEAT_URL, () => {})
-        .on("error", (e) => {
-          console.error("Failed to send heartbeat: %s", e);
-        });
-    }
-
     // Try to execute delayed set stakes if there are any. We check because this transaction still succeeds when there are not any and we don't want to waste gas in those cases.
     if (
       (await klerosLiquid.methods.lastDelayedSetStake().call()) >=
@@ -32,75 +24,75 @@ module.exports = async (web3, batchedSend) => {
       batchedSend({
         args: [DELAYED_STAKES_ITERATIONS],
         method: klerosLiquid.methods.executeDelayedSetStakes,
-        to: klerosLiquid.options.address
-      })
+        to: klerosLiquid.options.address,
+      });
 
     // Loop over all disputes.
     try {
-      let disputeID = 0
+      let disputeID = 0;
       while (true) {
         if (!executedDisputeIDs[disputeID]) {
-          const dispute = await klerosLiquid.methods.disputes(disputeID).call()
+          const dispute = await klerosLiquid.methods.disputes(disputeID).call();
           const dispute2 = await klerosLiquid.methods
             .getDispute(disputeID)
-            .call()
+            .call();
           const voteCounters = await Promise.all(
             // eslint-disable-next-line no-loop-func
             dispute2.votesLengths.map(async (numberOfVotes, i) => {
-              let voteCounter
+              let voteCounter;
               try {
                 voteCounter = await klerosLiquid.methods
                   .getVoteCounter(disputeID, i)
-                  .call()
+                  .call();
               } catch (_) {
                 // Look it up manually if numberOfChoices is too high for loop
-                let tied = true
-                let winningChoice = '0'
-                const _voteCounters = {}
+                let tied = true;
+                let winningChoice = "0";
+                const _voteCounters = {};
 
                 for (let j = 0; j < numberOfVotes; j++) {
                   const vote = await klerosLiquid.methods.getVote(
                     disputeID,
                     i,
                     j
-                  )
+                  );
                   if (vote.voted) {
                     // increment vote count
                     _voteCounters[vote.choice] = _voteCounters[vote.choice]
                       ? _voteCounters[vote.choice] + 1
-                      : 1
+                      : 1;
                     if (vote.choice === winningChoice) {
-                      if (tied) tied = false // broke tie
+                      if (tied) tied = false; // broke tie
                     } else {
                       const _winningChoiceVotes =
-                        _voteCounters[winningChoice] || 0
+                        _voteCounters[winningChoice] || 0;
                       if (_voteCounters[vote.choice] > _winningChoiceVotes) {
-                        winningChoice = vote.choice
-                        tied = false
+                        winningChoice = vote.choice;
+                        tied = false;
                       } else if (
                         _voteCounters[vote.choice] === _winningChoiceVotes
                       )
-                        tied = true
+                        tied = true;
                     }
                   }
                 }
 
                 voteCounter = {
                   tied,
-                  winningChoice
-                }
+                  winningChoice,
+                };
               }
 
-              return voteCounter
+              return voteCounter;
             })
-          )
+          );
 
           const notTieAndNoOneCoherent = voteCounters.map(
-            v =>
+            (v) =>
               !voteCounters[voteCounters.length - 1].tied &&
               v.counts[voteCounters[voteCounters.length - 1].winningChoice] ===
-                '0'
-          )
+                "0"
+          );
           if (
             !dispute.ruled ||
             dispute2.votesLengths.some(
@@ -118,7 +110,7 @@ module.exports = async (web3, batchedSend) => {
                   dispute.drawsInRound && {
                   args: [disputeID, 15],
                   method: klerosLiquid.methods.drawJurors,
-                  to: klerosLiquid.options.address
+                  to: klerosLiquid.options.address,
                 },
                 ...dispute2.votesLengths.map(
                   // eslint-disable-next-line no-loop-func
@@ -127,53 +119,69 @@ module.exports = async (web3, batchedSend) => {
                       Number(dispute2.repartitionsInEachRound[i]) && {
                       args: [disputeID, i, 15],
                       method: klerosLiquid.methods.execute,
-                      to: klerosLiquid.options.address
+                      to: klerosLiquid.options.address,
                     }
                 ),
                 {
                   args: [disputeID],
                   method: klerosLiquid.methods.executeRuling,
-                  to: klerosLiquid.options.address
+                  to: klerosLiquid.options.address,
                 },
                 {
                   args: [disputeID],
                   method: klerosLiquid.methods.passPeriod,
-                  to: klerosLiquid.options.address
-                }
-              ].filter(t => t)
-            )
-          else executedDisputeIDs[disputeID] = true // The dispute is finalized, cache it.
+                  to: klerosLiquid.options.address,
+                },
+              ].filter((t) => t)
+            );
+          else executedDisputeIDs[disputeID] = true; // The dispute is finalized, cache it.
         }
-        disputeID++
+        disputeID++;
       }
     } catch (_) {} // Reached the end of the disputes list.
 
     // Try to pass the phase.
-    let readyForNextPhase = false
-    const phase = await klerosLiquid.methods.phase().call()
-    const lastPhaseChange = await klerosLiquid.methods.lastPhaseChange().call()
-    const disputesWithoutJurors = await klerosLiquid.methods.disputesWithoutJurors().call()
+    let readyForNextPhase = false;
+    const phase = await klerosLiquid.methods.phase().call();
+    const lastPhaseChange = await klerosLiquid.methods.lastPhaseChange().call();
+    const disputesWithoutJurors = await klerosLiquid.methods
+      .disputesWithoutJurors()
+      .call();
     if (phase == PhaseEnum.staking) {
-      const minStakingTime = await klerosLiquid.methods.minStakingTime().call()
-      if ((Date.now() - lastPhaseChange * 1000 >= minStakingTime * 1000) && disputesWithoutJurors > 0) {
-        readyForNextPhase = true
+      const minStakingTime = await klerosLiquid.methods.minStakingTime().call();
+      if (
+        Date.now() - lastPhaseChange * 1000 >= minStakingTime * 1000 &&
+        disputesWithoutJurors > 0
+      ) {
+        readyForNextPhase = true;
       }
     } else if (phase == PhaseEnum.generating) {
-      readyForNextPhase = true
+      readyForNextPhase = true;
     } else if (phase == PhaseEnum.drawing) {
-      const maxDrawingTime = await klerosLiquid.methods.maxDrawingTime().call()
-      if ((Date.now() - lastPhaseChange * 1000 >= maxDrawingTime * 1000) || disputesWithoutJurors == 0) {
-        readyForNextPhase = true
+      const maxDrawingTime = await klerosLiquid.methods.maxDrawingTime().call();
+      if (
+        Date.now() - lastPhaseChange * 1000 >= maxDrawingTime * 1000 ||
+        disputesWithoutJurors == 0
+      ) {
+        readyForNextPhase = true;
       }
     }
 
     if (readyForNextPhase) {
       batchedSend({
         method: klerosLiquid.methods.passPhase,
-        to: klerosLiquid.options.address
-      })
+        to: klerosLiquid.options.address,
+      });
     }
 
-    await delay(1000 * 60 * 10) // Every 10 minutes
+    if (process.env.HEARTBEAT_URL) {
+      https
+        .get(process.env.HEARTBEAT_URL, () => {})
+        .on("error", (e) => {
+          console.error("Failed to send heartbeat: %s", e);
+        });
+    }
+
+    await delay(1000 * 60 * 10); // Every 10 minutes
   }
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const run = async (bot, { providerUrl, batcherAddress, privateKey }) => {
     } catch (err) {
       console.error('Bot error: ', err)
     }
-    await delay(10000) // Wait 10 seconds before restarting failed bot.
+    await delay(60000); // Wait 60 seconds before restarting failed bot.
   }
 }
 

--- a/src/xdai-bots/x-kleros-liquid.js
+++ b/src/xdai-bots/x-kleros-liquid.js
@@ -20,7 +20,7 @@ module.exports = async (web3, batchedSend) => {
 
   // Keep track of executed disputes so we don't waste resources on them.
   const executedDisputeIDs = {};
-
+  let doHeartbeat = true;
   while (true) {
     // Try to execute delayed set stakes if there are any. We check because this transaction still succeeds when there are not any and we don't want to waste gas in those cases.
     console.log("Initializing xKlerosLiquid loop...");
@@ -41,7 +41,7 @@ module.exports = async (web3, batchedSend) => {
         await xKlerosLiquid.methods.totalDisputes().call()
       );
       console.log("Looping over %s disputes...", totalDisputes);
-      for (let disputeID = 450; disputeID < totalDisputes; disputeID++) {
+      for (let disputeID = 0; disputeID < totalDisputes; disputeID++) {
         if (!executedDisputeIDs[disputeID]) {
           const dispute = await xKlerosLiquid.methods
             .disputes(disputeID)
@@ -158,6 +158,7 @@ module.exports = async (web3, batchedSend) => {
     } catch (e) {
       // do nothing...
       console.error("Error while looping over disputes:", e);
+      doHeartbeat = false;
     }
 
     // Try to pass the phase.
@@ -204,7 +205,7 @@ module.exports = async (web3, batchedSend) => {
       });
     }
 
-    if (process.env.HEARTBEAT_URL) {
+    if (process.env.HEARTBEAT_URL && doHeartbeat) {
       https
         .get(process.env.HEARTBEAT_URL, () => {})
         .on("error", (e) => {

--- a/src/xdai-bots/x-kleros-liquid.js
+++ b/src/xdai-bots/x-kleros-liquid.js
@@ -149,10 +149,11 @@ module.exports = async (web3, batchedSend) => {
                 },
               ].filter((t) => t)
             );
+            console.log("Callbacks for dispute %s processed.", disputeID);
           } else {
             executedDisputeIDs[disputeID] = true;
+            console.log("The dispute %s was already executed.", disputeID);
           } // The dispute is finalized, cache it.
-          console.log("The dispute %s is finalized.", disputeID);
         }
       }
     } catch (e) {

--- a/src/xdai-bots/x-kleros-liquid.js
+++ b/src/xdai-bots/x-kleros-liquid.js
@@ -1,35 +1,27 @@
-const delay = require('delay')
-const https = require('https')
-const _xKlerosLiquid = require('../contracts/x-kleros-liquid.json')
-const _randomAuRa = require('../contracts/random-au-ra.json')
+const delay = require("delay");
+const https = require("https");
+const _xKlerosLiquid = require("../contracts/x-kleros-liquid.json");
+const _randomAuRa = require("../contracts/random-au-ra.json");
 
-const DELAYED_STAKES_ITERATIONS = 15
+const DELAYED_STAKES_ITERATIONS = 15;
 
 module.exports = async (web3, batchedSend) => {
   // Instantiate the Kleros Liquid contract.
   const xKlerosLiquid = new web3.eth.Contract(
     _xKlerosLiquid.abi,
     process.env.XDAI_X_KLEROS_LIQUID_CONTRACT_ADDRESS
-  )
+  );
   const randomAuRa = new web3.eth.Contract(
     _randomAuRa.abi,
     await xKlerosLiquid.methods.RNGenerator().call()
-  )
+  );
 
-  const PhaseEnum = Object.freeze({ staking: 0, generating: 1, drawing: 2 })
+  const PhaseEnum = Object.freeze({ staking: 0, generating: 1, drawing: 2 });
 
   // Keep track of executed disputes so we don't waste resources on them.
-  const executedDisputeIDs = {}
+  const executedDisputeIDs = {};
 
   while (true) {
-    if (process.env.HEARTBEAT_URL) {
-      https
-        .get(process.env.HEARTBEAT_URL, () => {})
-        .on("error", (e) => {
-          console.error("Failed to send heartbeat: %s", e);
-        });
-    }
-
     // Try to execute delayed set stakes if there are any. We check because this transaction still succeeds when there are not any and we don't want to waste gas in those cases.
     if (
       (await xKlerosLiquid.methods.lastDelayedSetStake().call()) >=
@@ -38,76 +30,80 @@ module.exports = async (web3, batchedSend) => {
       batchedSend({
         args: [DELAYED_STAKES_ITERATIONS],
         method: xKlerosLiquid.methods.executeDelayedSetStakes,
-        to: xKlerosLiquid.options.address
-      })
+        to: xKlerosLiquid.options.address,
+      });
 
     // Loop over all disputes.
     try {
-      const totalDisputes = Number(await xKlerosLiquid.methods.totalDisputes().call())
+      const totalDisputes = Number(
+        await xKlerosLiquid.methods.totalDisputes().call()
+      );
 
-      for(let disputeID = 0; disputeID < totalDisputes; disputeID++) {
+      for (let disputeID = 0; disputeID < totalDisputes; disputeID++) {
         if (!executedDisputeIDs[disputeID]) {
-          const dispute = await xKlerosLiquid.methods.disputes(disputeID).call()
+          const dispute = await xKlerosLiquid.methods
+            .disputes(disputeID)
+            .call();
           const dispute2 = await xKlerosLiquid.methods
             .getDispute(disputeID)
-            .call()
+            .call();
           const voteCounters = await Promise.all(
             // eslint-disable-next-line no-loop-func
             dispute2.votesLengths.map(async (numberOfVotes, i) => {
-              let voteCounter
+              let voteCounter;
               try {
                 voteCounter = await xKlerosLiquid.methods
                   .getVoteCounter(disputeID, i)
-                  .call()
+                  .call();
               } catch (_) {
                 // Look it up manually if numberOfChoices is too high for loop
-                let tied = true
-                let winningChoice = '0'
-                const _voteCounters = {}
+                let tied = true;
+                let winningChoice = "0";
+                const _voteCounters = {};
 
                 for (let j = 0; j < numberOfVotes; j++) {
                   const vote = await xKlerosLiquid.methods.getVote(
                     disputeID,
                     i,
                     j
-                  )
+                  );
                   if (vote.voted) {
                     // increment vote count
                     _voteCounters[vote.choice] = _voteCounters[vote.choice]
                       ? _voteCounters[vote.choice] + 1
-                      : 1
+                      : 1;
                     if (vote.choice === winningChoice) {
-                      if (tied) tied = false // broke tie
+                      if (tied) tied = false; // broke tie
                     } else {
                       const _winningChoiceVotes =
-                        _voteCounters[winningChoice] || 0
+                        _voteCounters[winningChoice] || 0;
                       if (_voteCounters[vote.choice] > _winningChoiceVotes) {
-                        winningChoice = vote.choice
-                        tied = false
+                        winningChoice = vote.choice;
+                        tied = false;
                       } else if (
                         _voteCounters[vote.choice] === _winningChoiceVotes
                       )
-                        tied = true
+                        tied = true;
                     }
                   }
                 }
 
                 voteCounter = {
                   tied,
-                  winningChoice
-                }
+                  winningChoice,
+                };
               }
 
-              return voteCounter
+              return voteCounter;
             })
-          )
+          );
 
           const notTieAndNoOneCoherent = voteCounters.map(
-            v =>
+            (v) =>
               !voteCounters[voteCounters.length - 1].tied &&
               v.counts[voteCounters[voteCounters.length - 1].winningChoice] ===
-                '0'
-          )
+                "0"
+          );
           if (
             !dispute.ruled ||
             dispute2.votesLengths.some(
@@ -125,7 +121,7 @@ module.exports = async (web3, batchedSend) => {
                   dispute.drawsInRound && {
                   args: [disputeID, 15],
                   method: xKlerosLiquid.methods.drawJurors,
-                  to: xKlerosLiquid.options.address
+                  to: xKlerosLiquid.options.address,
                 },
                 ...dispute2.votesLengths.map(
                   // eslint-disable-next-line no-loop-func
@@ -134,23 +130,23 @@ module.exports = async (web3, batchedSend) => {
                       Number(dispute2.repartitionsInEachRound[i]) && {
                       args: [disputeID, i, 15],
                       method: xKlerosLiquid.methods.execute,
-                      to: xKlerosLiquid.options.address
+                      to: xKlerosLiquid.options.address,
                     }
                 ),
                 {
                   args: [disputeID],
                   method: xKlerosLiquid.methods.executeRuling,
-                  to: xKlerosLiquid.options.address
+                  to: xKlerosLiquid.options.address,
                 },
                 {
                   args: [disputeID],
                   method: xKlerosLiquid.methods.passPeriod,
-                  to: xKlerosLiquid.options.address
-                }
-              ].filter(t => t)
-            )
+                  to: xKlerosLiquid.options.address,
+                },
+              ].filter((t) => t)
+            );
           } else {
-            executedDisputeIDs[disputeID] = true
+            executedDisputeIDs[disputeID] = true;
           } // The dispute is finalized, cache it.
         }
       }
@@ -159,42 +155,56 @@ module.exports = async (web3, batchedSend) => {
     }
 
     // Try to pass the phase.
-    let readyForNextPhase = false
-    const phase = await xKlerosLiquid.methods.phase().call()
-    const lastPhaseChange = await xKlerosLiquid.methods.lastPhaseChange().call()
+    let readyForNextPhase = false;
+    const phase = await xKlerosLiquid.methods.phase().call();
+    const lastPhaseChange = await xKlerosLiquid.methods
+      .lastPhaseChange()
+      .call();
     const disputesWithoutJurors = await xKlerosLiquid.methods
       .disputesWithoutJurors()
-      .call()
+      .call();
     if (phase == PhaseEnum.staking) {
-      const minStakingTime = await xKlerosLiquid.methods.minStakingTime().call()
+      const minStakingTime = await xKlerosLiquid.methods
+        .minStakingTime()
+        .call();
       if (
         Date.now() - lastPhaseChange * 1000 >= minStakingTime * 1000 &&
         disputesWithoutJurors > 0
       ) {
-        readyForNextPhase = true
+        readyForNextPhase = true;
       }
     } else if (phase == PhaseEnum.generating) {
       const isCommitPhase = await randomAuRa.methods.isCommitPhase().call();
       if (isCommitPhase) {
-        readyForNextPhase = true
+        readyForNextPhase = true;
       }
     } else if (phase == PhaseEnum.drawing) {
-      const maxDrawingTime = await xKlerosLiquid.methods.maxDrawingTime().call()
+      const maxDrawingTime = await xKlerosLiquid.methods
+        .maxDrawingTime()
+        .call();
       if (
         Date.now() - lastPhaseChange * 1000 >= maxDrawingTime * 1000 &&
         disputesWithoutJurors == 0
       ) {
-        readyForNextPhase = true
+        readyForNextPhase = true;
       }
     }
 
     if (readyForNextPhase) {
       batchedSend({
         method: xKlerosLiquid.methods.passPhase,
-        to: xKlerosLiquid.options.address
-      })
+        to: xKlerosLiquid.options.address,
+      });
     }
 
-    await delay(5 * 60 * 1000) // Every 5 minutes
+    if (process.env.HEARTBEAT_URL) {
+      https
+        .get(process.env.HEARTBEAT_URL, () => {})
+        .on("error", (e) => {
+          console.error("Failed to send heartbeat: %s", e);
+        });
+    }
+
+    await delay(5 * 60 * 1000); // Every 5 minutes
   }
-}
+};


### PR DESCRIPTION
The gas logic has to be fixed because in gnosis chain sometimes the gas is < than 1 gwei, which means that the tx generation will fail because the priority fee > total gas.

Also, I've included a flag to send the heartbeat only when there is no error.

On top of that, some logs were added to make easier the debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging throughout bot operations for improved observability.
  - Added control over heartbeat signaling with a new flag.

- **Bug Fixes**
  - Improved error reporting and handling during dispute processing.

- **Refactor**
  - Ensured sequential execution of asynchronous operations.
  - Updated transaction fee handling to support EIP-1559 fee structure.

- **Chores**
  - Increased delay after bot failures for more robust restart behavior.
  - Reformatted code for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->