### PR TITLE
fix: move doHeartbeat declaration inside the loop

### DIFF
--- a/src/bots/kleros-liquid.js
+++ b/src/bots/kleros-liquid.js
@@ -15,8 +15,8 @@ module.exports = async (web3, batchedSend) => {
   // Keep track of executed disputes so we don't waste resources on them.
   const executedDisputeIDs = {};
 
-  let doHeartbeat = true;
   while (true) {
+    let doHeartbeat = true;
     console.log("Initializing klerosLiquid loop...");
     // Try to execute delayed set stakes if there are any. We check because this transaction still succeeds when there are not any and we don't want to waste gas in those cases.
     if (


### PR DESCRIPTION
With the previous way of setting the heartbeat flag, if the application failed in one of the loops, it would never send the heartbeat again. So, I moved the flag variable inside the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected heartbeat state management to reset each cycle iteration, preventing persistent errors from blocking subsequent heartbeat attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->